### PR TITLE
Update Phone Input Styling for Transparent Background in Dark Mode

### DIFF
--- a/components/Livedemo/Livedemo.tsx
+++ b/components/Livedemo/Livedemo.tsx
@@ -1,8 +1,18 @@
 "use client"; // Add this line at the top
 
 import { useState } from "react";
-import PhoneInput from 'react-phone-input-2';
+import PhoneInput, { PhoneInputProps } from 'react-phone-input-2';
 import 'react-phone-input-2/lib/style.css';
+import './customPhoneInput.css'; // Your custom styles
+
+// Step 1: Define the extended type and custom component
+interface ExtendedPhoneInputProps extends PhoneInputProps {
+  className?: string;
+}
+
+const CustomPhoneInput: React.FC<ExtendedPhoneInputProps> = (props) => {
+  return <PhoneInput {...props} />;
+};
 
 const Livedemo = () => {
   const [activeContent, setActiveContent] = useState<string>("livedemo");
@@ -95,24 +105,12 @@ const Livedemo = () => {
                       >
                         Phone Number
                       </label>
-                       <PhoneInput
-        country={'in'}
-        value={phone}
-        onChange={(phone: string) => setPhone(phone)}
-        inputStyle={{
-          width: '100%',
-          border: '1px solid #d1d5db', // Example border color
-          backgroundColor: '#f8f8f8', // Example background color
-          padding: '24px 45px', // Example padding
-          borderRadius: '2px', // Example border radius
-          outline: 'none',
-          transition: 'all 0.3s ease',
-        }}
-        buttonStyle={{
-          borderRadius: '4px 0 0 4px', // Match the input border radius
-        }}
-        
-      />
+                       <CustomPhoneInput
+                        country={'in'}
+                        value={phone}
+                        onChange={(phone: string) => setPhone(phone)}
+                        className=" dark:text-body-color-dark dark:shadow-two w-full rounded-sm border bg-[#f8f8f8] px-6 py-3 text-base text-body-color outline-none transition-all duration-300 focus:border-[#45988e] dark:border-transparent dark:bg-[#2C303B] dark:focus:border-[#45988e] dark:focus:shadow-none"
+                      />
                     </div>
                   </div>
                 ) : (

--- a/components/Livedemo/customPhoneInput.css
+++ b/components/Livedemo/customPhoneInput.css
@@ -1,0 +1,77 @@
+/* Ensure the container is styled correctly */
+.react-tel-input {
+  display: flex;
+  align-items: center;
+}
+
+/* Customize the flag dropdown */
+.react-tel-input .flag-dropdown .selected-flag {
+  padding-right: 0; 
+  background-color: transparent;
+  border: none;
+}
+
+/* Remove the flag icon background color */
+.react-tel-input .flag-dropdown .selected-flag .flag {
+  background-color: transparent;
+}
+
+/* Customize the input */
+.react-tel-input .form-control {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+  color: inherit;
+  font-size: inherit;
+  height: auto;
+  width: 100%;
+}
+
+/* Hide unnecessary parts */
+.react-tel-input .flag-dropdown {
+  background-color: transparent;
+  border: none;
+}
+
+/* Ensure the dropdown remains transparent when clicked */
+.react-tel-input .flag-dropdown.open .selected-flag,
+.react-tel-input .flag-dropdown.open .selected-flag .flag,
+.react-tel-input .flag-dropdown.open .selected-flag .arrow {
+  background-color: transparent !important;
+}
+
+/* Ensure the input remains transparent when focused or active */
+.react-tel-input .form-control:focus,
+.react-tel-input .form-control:active,
+.react-tel-input .form-control.open {
+  background-color: transparent !important;
+}
+
+/* Ensure the dropdown list remains transparent when focused or hovered */
+.react-tel-input .country-list .country:hover,
+.react-tel-input .country-list .country:focus {
+  background-color: white;
+}
+
+/* Additional styling for the flag dropdown when the list is open */
+.react-tel-input .flag-dropdown.open,
+.react-tel-input .flag-dropdown:focus,
+.react-tel-input .flag-dropdown:active {
+  background-color: transparent !important;
+  border: none;
+}
+
+/* Ensure no background color change for any interactive state of the dropdown */
+.react-tel-input .flag-dropdown .selected-flag:focus,
+.react-tel-input .flag-dropdown .selected-flag:active,
+.react-tel-input .flag-dropdown.open .selected-flag:focus,
+.react-tel-input .flag-dropdown.open .selected-flag:active {
+  background-color: transparent !important;
+}
+
+/* Ensure the dropdown arrow does not change the background */
+.react-tel-input .flag-dropdown .selected-flag .arrow,
+.react-tel-input .flag-dropdown.open .selected-flag .arrow:focus,
+.react-tel-input .flag-dropdown.open .selected-flag .arrow:active {
+  background-color: transparent !important;
+}

--- a/styles/index.css
+++ b/styles/index.css
@@ -34,4 +34,28 @@
   input#checkboxLabel:checked ~ .box span {
     @apply opacity-100;
   }
+  
+   /* Add your custom phone input styles here */
+   .custom-phone-input .form-control {
+    @apply border border-gray-300 bg-gray-100 text-gray-700 w-full p-3 rounded-md outline-none transition-all duration-300;
+  }
+
+  .custom-phone-input .form-control:focus {
+    @apply border-green-500;
+    box-shadow: none;
+  }
+
+  .custom-phone-input .form-control:disabled {
+    @apply bg-gray-200;
+  }
+
+  .custom-phone-input .flag-dropdown {
+    @apply bg-gray-100 border border-gray-300 rounded-md;
+  }
+
+  .custom-phone-input .flag-dropdown:hover {
+    @apply bg-gray-200;
+  }
+
 }
+


### PR DESCRIPTION
1) Changes Made:
- Set the background-color of the phone input component to transparent to ensure it displays correctly in dark mode.
- Removed white background to improve visibility and consistency across themes.

2)Testing:
- Tested in both light and dark modes to verify transparent background behavior.
- Ensured compatibility with existing styling and responsiveness.